### PR TITLE
Unicode out of range fix

### DIFF
--- a/MitreAttack/Attack.py
+++ b/MitreAttack/Attack.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import requests
 import json
 from . import Technique

--- a/MitreAttack/Group.py
+++ b/MitreAttack/Group.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 class Group:
 	ID = ""
 	displaytitle = ""
@@ -6,10 +8,10 @@ class Group:
 	aliases = []
 
 	def __init__(self, ID, displaytitle, description, fullurl, aliases, techniques, software):
-		self.ID = ID
-		self.displaytitle = displaytitle
-		self.description = description
-		self.fullurl = fullurl
+		self.ID = ID.encode('ascii','replace')
+		self.displaytitle = displaytitle.encode('ascii','replace')
+		self.description = description.encode('ascii','replace')
+		self.fullurl = fullurl.encode('ascii','replace')
 		self.aliases = aliases
 		self.techniques = {}
 		self.software = {}
@@ -19,10 +21,10 @@ class Group:
 			self.software[item['fulltext'].split('/')[1]] = item
 
 	def __str__(self):
-		return "{}: {}".format(self.ID, self.displaytitle)
+		return "{}: {}".format(self.ID.encode('ascii','replace'), self.displaytitle.encode('ascii','replace'))
 
 	def __repr__(self):
-		return "{}: {}".format(self.ID, self.displaytitle)
+		return "{}: {}".format(self.ID.encode('ascii','replace'), self.displaytitle.encode('ascii','replace'))
 
 	def search(self,query):
 		pass

--- a/MitreAttack/Software.py
+++ b/MitreAttack/Software.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 class Software:
 	ID = ""
 	displaytitle = ""
@@ -6,10 +8,10 @@ class Software:
 	aliases = []
 
 	def __init__(self, ID, displaytitle, description, fullurl, aliases, techniques):
-		self.ID = ID
-		self.displaytitle = displaytitle
-		self.description = description
-		self.fullurl = fullurl
+		self.ID = ID.encode('ascii','replace')
+		self.displaytitle = displaytitle.encode('ascii','replace')
+		self.description = description.encode('ascii','replace')
+		self.fullurl = fullurl.encode('ascii','replace')
 		self.aliases = aliases
 		self.techniques = {}
 		self.groups = {}
@@ -17,10 +19,10 @@ class Software:
 			self.techniques[tech['fulltext'].split('/')[1]] = tech
 
 	def __str__(self):
-		return "{}: {}".format(self.ID, self.displaytitle)
+		return "{}: {}".format(self.ID.encode('ascii','replace'), self.displaytitle.encode('ascii','replace'))
 
 	def __repr__(self):
-		return "{}: {}".format(self.ID, self.displaytitle)
+		return "{}: {}".format(self.ID.encode('ascii','replace'), self.displaytitle.encode('ascii','replace'))
 
 	def search(self,query):
 		pass

--- a/MitreAttack/Tactic.py
+++ b/MitreAttack/Tactic.py
@@ -1,12 +1,14 @@
+
+# -*- coding: utf-8 -*-
 class Tactic:
 	fulltext = ""
 	description = ""
 	fullurl = ""
 
 	def __init__(self, fulltext, description, fullurl):
-		self.fulltext = fulltext
-		self.description = description
-		self.fullurl = fullurl
+		self.fulltext = fulltext.encode("utf-8")
+		self.description = description.encode("utf-8")
+		self.fullurl = fullurl.encode("utf-8")
 		self.techniques = {}
 
 	def __str__(self):

--- a/MitreAttack/Technique.py
+++ b/MitreAttack/Technique.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 class Technique:
 	ID = ""
 	displaytitle = ""
@@ -6,10 +8,10 @@ class Technique:
 	data_sources = []
 
 	def __init__(self, ID, displaytitle, technical_description, data_sources, full_url, thetactics):
-		self.ID = ID
-		self.displaytitle = displaytitle
-		self.technical_description = technical_description
-		self.full_url = full_url
+		self.ID = ID.encode('ascii','replace')
+		self.displaytitle = displaytitle.encode('ascii','replace')
+		self.technical_description = technical_description.encode('ascii','replace')
+		self.full_url = full_url.encode('ascii','replace')
 		self.data_sources = data_sources
 		self.tactics = {}
 		self.groups = {}
@@ -18,10 +20,10 @@ class Technique:
 			self.tactics[i['fulltext']] = i
 
 	def __str__(self):
-		return "{}: {}".format(self.ID,self.displaytitle)
+		return "{}: {}".format(self.ID.encode('ascii','replace') ,self.displaytitle.encode('ascii','replace'))
 
 	def __repr__(self):
-		return "{}: {}".format(self.ID,self.displaytitle)
+		return "{}: {}".format(self.ID.encode('ascii','replace'),self.displaytitle.encode('ascii','replace'))
 
 	def search(self):
 		pass

--- a/MitreAttack/__init__.py
+++ b/MitreAttack/__init__.py
@@ -1,1 +1,3 @@
+# -*- coding: utf-8 -*-
+
 from Attack import Attack


### PR DESCRIPTION
Your version does not handle out of range unicode characters. This fix replaces them with '?' so that it does not crash. Try the error by searching for techniques with 'd' as parameter. Doppelganger technique crashes it.